### PR TITLE
Added encoding line to server.py

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,4 +1,6 @@
 import SocketServer
+# coding: utf-8
+
 # Copyright 2013 Abram Hindle
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Some versions of Python may complain about the little UTF-8 '©' in the file.

```
SyntaxError: Non-ASCII character '\xc2' in file server.py on line 19
```

I added the [`coding`](http://www.python.org/dev/peps/pep-0263/) thing on line 2 to fix it.

BY THE WAY, how does licensing work with pull requests?
