### PR TITLE
Convert provided code to python3

### DIFF
--- a/freetests.py
+++ b/freetests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2013 Abram Hindle
+# Copyright 2013 Abram Hindle, Cole Mackenzie
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 # run python freetests.py
 
-import urllib2
+import urllib.request
 import unittest
 
 BASEURL = "http://127.0.0.1:8080"
@@ -27,27 +27,27 @@ class TestYourWebserver(unittest.TestCase):
 
     def test_css(self):
         url = self.baseurl + "/base.css"
-        req = urllib2.urlopen(url, None, 3)
+        req = urllib.request.urlopen(url, None, 3)
         self.assertTrue( req.getcode()  == 200 , "200 OK Not FOUND!")
         self.assertTrue( req.info().gettype() == "text/css", ("Bad mimetype for css! %s" % req.info().gettype()))
 
     def test_get_root(self):
         url = self.baseurl + "/"
-        req = urllib2.urlopen(url, None, 3)
+        req = urllib.request.urlopen(url, None, 3)
         self.assertTrue( req.getcode()  == 200 , "200 OK Not FOUND!")
 
     def test_get_indexhtml(self):
         url = self.baseurl + "/index.html"
-        req = urllib2.urlopen(url, None, 3)
+        req = urllib.request.urlopen(url, None, 3)
         self.assertTrue( req.getcode()  == 200 , "200 OK Not FOUND!")
 
 
     def test_get_404(self):
         url = self.baseurl + "/do-not-implement-this-page-it-is-not-found"
         try:
-            req = urllib2.urlopen(url, None, 3)
+            req = urllib.request.urlopen(url, None, 3)
             self.assertTrue( False, "Should have thrown an HTTP Error!")
-        except urllib2.HTTPError as e:
+        except urllib.request.HTTPError as e:
             self.assertTrue( e.getcode()  == 404 , ("404 Not FOUND! %d" % e.getcode()))
         else:
             self.assertTrue( False, "Another Error was thrown!")

--- a/not-free-tests.py
+++ b/not-free-tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2013 Abram Hindle
+# Copyright 2013 Abram Hindle, Cole Mackenzie
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 # run: python not-free-tests.py
 
-import urllib2
+import urllib.request
 import unittest
 import os
 
@@ -28,26 +28,26 @@ class TestYourWebserver(unittest.TestCase):
 
     def test_get_root(self):
         url = self.baseurl + "/"
-        req = urllib2.urlopen(url, None, 3)
+        req = urllib.request.urlopen(url, None, 3)
         self.assertTrue( req.getcode()  == 200 , "200 OK Not FOUND!")
 
     def test_get_deep(self):
         url = self.baseurl + "/deep/"
-        req = urllib2.urlopen(url, None, 3)
+        req = urllib.request.urlopen(url, None, 3)
         self.assertTrue( req.getcode()  == 200 , "200 OK Not FOUND!")
 
 
     def test_get_index(self):
         url = self.baseurl + "/index.html"
-        req = urllib2.urlopen(url, None, 3)
+        req = urllib.request.urlopen(url, None, 3)
         self.assertTrue( req.getcode()  == 200 , "200 OK Not FOUND!")
 
     def test_get_404(self):
         url = self.baseurl + "/do-not-implement-this-page-it-is-not-found"
         try:
-            req = urllib2.urlopen(url, None, 3)
+            req = urllib.request.urlopen(url, None, 3)
             self.assertTrue( False, "Should have thrown an HTTP Error!")
-        except urllib2.HTTPError as e:
+        except urllib.request.HTTPError as e:
             self.assertTrue( e.getcode()  == 404 , ("404 Not FOUND! %d" % e.getcode()))
         else:
             self.assertTrue( False, "Another Error was thrown!")
@@ -56,50 +56,50 @@ class TestYourWebserver(unittest.TestCase):
         """ how secure are you? """
         url = self.baseurl + "/../../../../../../../../../../../../etc/group"
         try:
-            req = urllib2.urlopen(url, None, 3)
+            req = urllib.request.urlopen(url, None, 3)
             self.assertTrue( False, "Should have thrown an HTTP Error! [%d]" % req.getcode())
-        except urllib2.HTTPError as e:
+        except urllib.request.HTTPError as e:
             self.assertTrue( e.getcode()  == 404 , ("404 Not FOUND! %d" % e.getcode()))
         else:
             self.assertTrue( false, "Another Error was thrown!")
         
     def test_css(self):
         url = self.baseurl + "/base.css"
-        req = urllib2.urlopen(url, None, 3)
+        req = urllib.request.urlopen(url, None, 3)
         self.assertTrue( req.getcode()  == 200 , "200 OK Not FOUND!")
         self.assertTrue( req.info().gettype() == "text/css", ("Bad mimetype for css! %s" % req.info().gettype()))
 
     def test_html(self):
         url = self.baseurl + "/index.html"
-        req = urllib2.urlopen(url, None, 3)
+        req = urllib.request.urlopen(url, None, 3)
         self.assertTrue( req.getcode()  == 200 , "200 OK Not FOUND!")
         self.assertTrue( req.info().gettype() == "text/html", ("Bad mimetype for html! %s" % req.info().gettype()))
 
     def test_hardcode(self):
         os.system("cp -r www/deep www/hardcode")
         url = self.baseurl + "/hardcode/index.html"
-        req = urllib2.urlopen(url, None, 3)
+        req = urllib.request.urlopen(url, None, 3)
         self.assertTrue( req.getcode()  == 200 , "200 OK Not FOUND! Hardcoding? /hardcode/index.html")
         self.assertTrue( req.info().gettype() == "text/html", ("Bad mimetype for html! %s" % req.info().gettype()))
         url = self.baseurl + "/hardcode/"
-        req = urllib2.urlopen(url, None, 3)
+        req = urllib.request.urlopen(url, None, 3)
         self.assertTrue( req.getcode()  == 200 , "200 OK Not FOUND! Hardcoding? /hardcode/")
         self.assertTrue( req.info().gettype() == "text/html", ("Bad mimetype for html! %s" % req.info().gettype()))
 
     def test_hardcode2(self):
         url = self.baseurl + "/deep.css"
         try:
-            req = urllib2.urlopen(url, None, 3)
+            req = urllib.request.urlopen(url, None, 3)
             self.assertTrue( False, "Should have thrown an HTTP Error for /deep.css!")
-        except urllib2.HTTPError as e:
+        except urllib.request.HTTPError as e:
             self.assertTrue( e.getcode()  == 404 , ("404 Not FOUND! %d" % e.getcode()))
         else:
             self.assertTrue( False, "Another Error was thrown!")
         url = self.baseurl + "/deep/deep"
         try:
-            req = urllib2.urlopen(url, None, 3)
+            req = urllib.request.urlopen(url, None, 3)
             self.assertTrue( False, "Should have thrown an HTTP Error for /deep/deep!")
-        except urllib2.HTTPError as e:
+        except urllib.request.HTTPError as e:
             self.assertTrue( e.getcode()  == 404 , ("404 Not FOUND! %d" % e.getcode()))
         else:
             self.assertTrue( False, "Another Error was thrown!")

--- a/server.py
+++ b/server.py
@@ -28,7 +28,7 @@ import socketserver
 
 import socketserver
 
-class MyTCPHandler(socketserver.BaseRequestHandler):
+class MyWebServer(socketserver.BaseRequestHandler):
     """
     The RequestHandler class for our server.
 
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     HOST, PORT = "localhost", 8080
 
     # Create the server, binding to localhost on port 8080
-    with socketserver.TCPServer((HOST, PORT), MyTCPHandler) as server:
+    with socketserver.TCPServer((HOST, PORT), MyWebServer) as server:
         # Activate the server; this will keep running until you
         # interrupt the program with Ctrl-C
         server.serve_forever()

--- a/server.py
+++ b/server.py
@@ -1,7 +1,7 @@
 #  coding: utf-8 
-import SocketServer
+import socketserver
 
-# Copyright 2013 Abram Hindle, Eddie Antonio Santos
+# Copyright 2013 Abram Hindle, Eddie Antonio Santos, Cole Mackenzie
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,27 +20,33 @@ import SocketServer
 # some of the code is Copyright © 2001-2013 Python Software
 # Foundation; All Rights Reserved
 #
-# http://docs.python.org/2/library/socketserver.html
+# https://docs.python.org/3.7/library/socketserver.html
 #
 # run: python freetests.py
 
 # try: curl -v -X GET http://127.0.0.1:8080/
 
+import socketserver
 
-class MyWebServer(SocketServer.BaseRequestHandler):
-    
+class MyTCPHandler(socketserver.BaseRequestHandler):
+    """
+    The RequestHandler class for our server.
+
+    It is instantiated once per connection to the server, and must
+    override the handle() method to implement communication to the
+    client.
+    """
     def handle(self):
+        # self.request is the TCP socket connected to the client
         self.data = self.request.recv(1024).strip()
         print ("Got a request of: %s\n" % self.data)
-        self.request.sendall("OK")
+        self.request.sendall(b'OK')
 
 if __name__ == "__main__":
     HOST, PORT = "localhost", 8080
 
-    SocketServer.TCPServer.allow_reuse_address = True
     # Create the server, binding to localhost on port 8080
-    server = SocketServer.TCPServer((HOST, PORT), MyWebServer)
-
-    # Activate the server; this will keep running until you
-    # interrupt the program with Ctrl-C
-    server.serve_forever()
+    with socketserver.TCPServer((HOST, PORT), MyTCPHandler) as server:
+        # Activate the server; this will keep running until you
+        # interrupt the program with Ctrl-C
+        server.serve_forever()


### PR DESCRIPTION
Converted the python code to Python3 as `SocketServer` and `urllib2` are renamed/refactored in Python3.

Updated contributions.

Test:
``` bash
# run python server.py
(cmput404a1) |15:15:07|colemackenzie@Coles-MBP:[CMPUT404-assignment-webserver]> telnet 127.0.0.1 8080
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
GET /
OKConnection closed by foreign host.
```